### PR TITLE
Add support for webassembly static file type

### DIFF
--- a/QtWebApp/httpserver/staticfilecontroller.cpp
+++ b/QtWebApp/httpserver/staticfilecontroller.cpp
@@ -140,6 +140,10 @@ void StaticFileController::setContentType(const QString fileName, HttpResponse &
     {
         response.setHeader("Content-Type", "application/pdf");
     }
+    else if (fileName.endsWith(".wasm"))
+    {
+        response.setHeader("Content-Type", "application/wasm");
+    }
     else if (fileName.endsWith(".txt"))
     {
         response.setHeader("Content-Type", qPrintable("text/plain; charset="+encoding));


### PR DESCRIPTION
A really great library for providing an embedded http server!
I would like to use the http server to deliver webassembly files, so I added a new content type for webassembly binaries. Maybe you like to integrate this small patch into your repository?  